### PR TITLE
[UI] Remove warnings in console

### DIFF
--- a/ui/src/components/TaskRunsCard/index.jsx
+++ b/ui/src/components/TaskRunsCard/index.jsx
@@ -239,7 +239,7 @@ export default class TaskRunsCard extends Component {
         pageSize={ARTIFACTS_PAGE_SIZE}
         columnsSize={3}
         onPageChange={onArtifactsPageChange}
-        renderRow={({ node: artifact }) => (
+        renderRow={({ node: artifact }) => {
           <TableRow
             key={`run-artifact-${run.taskId}-${run.runId}-${artifact.name}`}
             className={classNames(
@@ -281,7 +281,7 @@ export default class TaskRunsCard extends Component {
               </TableCell>
             </Link>
           </TableRow>
-        )}
+        }}
       />
     );
   }


### PR DESCRIPTION
This PR fixes the issue #1545, which shows a bunch of `Warning: validateDOMNesting(...): warnings.` in the console when navigating to the link [http://localhost:5080/tasks/MH_HRhwxRZ-3zk7AvF0_vQ](url).